### PR TITLE
[EH][DDCE-1278] Changed sbt-scoverage due to coverage errors

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 


### PR DESCRIPTION
**Bug fix:** version 1.6.0 is marked as the latest sbt-scoverage incorrectly (see https://github.com/scoverage/sbt-scoverage/issues/311). This version seems to cause issues with accurately calculating test coverage. Bumped to latest version which is 1.6.1