### PR TITLE
DDCE-6516 - Fix pekko warning

### DIFF
--- a/app/controllers/GatewayNPSController.scala
+++ b/app/controllers/GatewayNPSController.scala
@@ -39,7 +39,9 @@ class GatewayNPSController @Inject() (
     extends BackendController(cc)
     with Logging {
 
-  private val notAllowCarryHeaders = Set(HeaderNames.CONTENT_LENGTH, HeaderNames.CONTENT_TYPE).map(_.toLowerCase)
+  private val notAllowCarryHeaders =
+    Set(HeaderNames.CONTENT_LENGTH, HeaderNames.CONTENT_TYPE, HeaderNames.TRANSFER_ENCODING)
+      .map(_.toLowerCase)
 
   /** Maps an HttpResponse to a Play Result Because HttpResponse from play and Result from play have different ways of
     * representing headers, had to write this custom mapping logic to convert the headers from Map[String,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10


### PR DESCRIPTION
to fix `Explicitly set HTTP header 'Transfer-Encoding: chunked' is ignored, the pekko-http-core layer sets this header automatically!` same issue in QA and PROD